### PR TITLE
add largeTitleWidget parameter to SuperLargeTitle

### DIFF
--- a/lib/models/super_large_title.model.dart
+++ b/lib/models/super_large_title.model.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 class SuperLargeTitle {
   SuperLargeTitle({
     this.largeTitle = "Hello Super Human",
+    this.largeTitleWidget,
     this.actions,
     this.textStyle = const TextStyle(
       inherit: false,
@@ -18,6 +19,8 @@ class SuperLargeTitle {
 
   final bool enabled;
   final String largeTitle;
+  // If largeTitleWidget is not null, largeTitle will be ignored
+  final Widget? largeTitleWidget;
   final List<Widget>? actions;
   final TextStyle textStyle;
 

--- a/lib/src/super_cupertino_navigation_bar.dart
+++ b/lib/src/super_cupertino_navigation_bar.dart
@@ -173,7 +173,7 @@ class _SuperScaffoldState extends State<SuperScaffold> {
       userMiddle: widget.appBar.title,
       userTrailing: widget.appBar.actions,
       largeTitleActions: Row(children: [...?widget.appBar.largeTitle!.actions]),
-      userLargeTitle: Text(
+      userLargeTitle: widget.appBar.largeTitle?.largeTitleWidget ?? Text(
         widget.appBar.largeTitle!.largeTitle,
         style: widget.appBar.largeTitle!.textStyle.copyWith(
           color: widget.appBar.largeTitle!.textStyle.color ??


### PR DESCRIPTION
## Enhance SuperLargeTitle with Optional Widget Support

This pull request introduces a new parameter to SuperLargeTitle, `largeTitleWidget`, enabling the use of custom widgets instead of static strings. 

**Benefits:**

- Increased flexibility for developers to create dynamic and interactive title sections.
- Improved visual customization beyond simple text.

**Behavior:**

- If `largeTitleWidget` is omitted, SuperLargeTitle functions as before with the `largeTitle` string.
- When provided, `largeTitleWidget` takes precedence, overriding the text and its styling.

**Impact:**

- Backward compatibility is maintained.
- Developers gain more control over title appearance and behavior.

Please review and provide feedback!


![simulator_screenshot_6AA9BF7E-2A67-454F-981E-634A1997D984](https://github.com/kspo/super_cupertino_navigation_bar/assets/46827004/39e4dd05-c750-484c-91a7-1bcb656e3b1e)
